### PR TITLE
[NOCARD] Fix rendering percent sign when multiple values files are supplied as parameter

### DIFF
--- a/ssm.sh
+++ b/ssm.sh
@@ -125,8 +125,8 @@ for FILEPATH in "${VALUE_FILES[@]}"; do
         exit 1
     fi
 
-    VALUE=$(echo -e "${VALUE}" | sed s/\%/\%\%/g) # we turn single % to %% to escape percent signs
-    printf -v MERGED_TEXT "${MERGED_TEXT}\n${VALUE}" # We concat the files together with a newline in between using printf and put output into variable MERGED_TEXT
+    #VALUE=$(echo -e "${VALUE}" | sed s/\%/\%\%/g) # we turn single % to %% to escape percent signs
+    echo -e MERGED_TEXT "${MERGED_TEXT}\n${VALUE}" # We concat the files together with a newline in between using printf and put output into variable MERGED_TEXT
 done
 
 PARAMETERS=$(echo -e "${MERGED_TEXT}" | grep -Eo "\{\{ssm [^\}]+\}\}") # Look for {{ssm /path/to/param us-east-1}} patterns, delete empty lines
@@ -142,7 +142,7 @@ while read -r PARAM_STRING; do
     REGION=$(echo ${CLEANED_PARAM_STRING:2} | cut -d' ' -f 3) # {{ssm /param/path *us-east-1*}}
     PROFILE=$(echo ${CLEANED_PARAM_STRING:2} | cut -d' ' -f 4) # {{ssm /param/path us-east-1 *production*}}
     if [[ -n ${PROFILE}  ]]; then
-       PROFILE_PARAM="--profile ${PROFILE}"  
+       PROFILE_PARAM="--profile ${PROFILE}"
     fi
     PARAM_OUTPUT="$(aws ssm get-parameter --with-decryption --name ${PARAM_PATH} --output text --query Parameter.Value --region ${REGION} $PROFILE_PARAM  2>&1)" # Get the parameter value or error message
     EXIT_CODE=$?

--- a/ssm.sh
+++ b/ssm.sh
@@ -126,7 +126,7 @@ for FILEPATH in "${VALUE_FILES[@]}"; do
     fi
 
     #VALUE=$(echo -e "${VALUE}" | sed s/\%/\%\%/g) # we turn single % to %% to escape percent signs
-    echo -e MERGED_TEXT "${MERGED_TEXT}\n${VALUE}" # We concat the files together with a newline in between using printf and put output into variable MERGED_TEXT
+    MERGED_TEXT=$(echo -e "${MERGED_TEXT}\n${VALUE}") # We concat the files together with a newline in between using printf and put output into variable MERGED_TEXT
 done
 
 PARAMETERS=$(echo -e "${MERGED_TEXT}" | grep -Eo "\{\{ssm [^\}]+\}\}") # Look for {{ssm /path/to/param us-east-1}} patterns, delete empty lines


### PR DESCRIPTION
- Fixes cases when there are multiple values files passed over to `helm ssm template` and there is a percent character in the values files, by replacing `printf` with `echo -e` as `%` in printf is a format character.