### PR TITLE
[NOCARD] Fix/ignore commented lines

### DIFF
--- a/ssm.sh
+++ b/ssm.sh
@@ -117,7 +117,7 @@ for FILEPATH in "${VALUE_FILES[@]}"; do
         exit 1
     fi
 
-    VALUE=$(cat ${FILEPATH} 2> /dev/null) # read the content of the values file silently (without outputing an error in case it fails)
+    VALUE=$(cat ${FILEPATH} | grep -v '^ *#' 2> /dev/null) # read the content of the values file silently (without outputing an error in case it fails)
     EXIT_CODE=$?
 
     if [[ ${EXIT_CODE} -ne 0 ]]; then


### PR DESCRIPTION
Ignore lines that are commented out. 

Reason:

In ArgoCD Helm chart, there's [this](https://github.com/argoproj/argo-helm/blob/master/charts/argo-cd/values.yaml#L1125) line.

```
# `htpasswd -nbBC 10 "" $ARGO_PWD | tr -d ':\n' | sed 's/$2y/$2a/'`
```

which line due to the `\n` in there gets interpreted by the various `echo -e` actions in the script later.

This PR aims to fix this issue by ignoring lines that are commented out in the first place. 